### PR TITLE
Increased Robustness: Prevent crashes if dataset contains only identical elements

### DIFF
--- a/betacal/beta_calibration.py
+++ b/betacal/beta_calibration.py
@@ -44,7 +44,8 @@ def _beta_calibration(df, y, sample_weight=None):
         b = coefs[1]
     inter = lr.intercept_[0]
 
-    m = minimize_scalar(lambda mh: np.abs(b*np.log(1.-mh)-a*np.log(mh)-inter),
+    a_, b_ = a or 0, b or 0
+    m = minimize_scalar(lambda mh: np.abs(b_*np.log(1.-mh)-a_*np.log(mh)-inter),
                         bounds=[0, 1], method='Bounded').x
     map = [a, b, m]
     return map, lr

--- a/betacal/beta_calibration.py
+++ b/betacal/beta_calibration.py
@@ -30,7 +30,7 @@ def _beta_calibration(df, y, sample_weight=None):
         lr = LogisticRegression(C=99999999999)
         lr.fit(x, y, sample_weight)
         coefs = lr.coef_[0]
-        a = 0
+        a = None
         b = coefs[0]
     elif coefs[1] < 0:
         x = x[:, 0].reshape(-1, 1)
@@ -38,7 +38,7 @@ def _beta_calibration(df, y, sample_weight=None):
         lr.fit(x, y, sample_weight)
         coefs = lr.coef_[0]
         a = coefs[0]
-        b = 0
+        b = None
     else:
         a = coefs[0]
         b = coefs[1]
@@ -112,9 +112,9 @@ class _BetaCal(BaseEstimator, RegressorMixin):
         x = np.hstack((df, 1. - df))
         x = np.log(x)
         x[:, 1] *= -1
-        if self.map_[0] == 0:
+        if self.map_[0] == None:
             x = x[:, 1].reshape(-1, 1)
-        elif self.map_[1] == 0:
+        elif self.map_[1] == None:
             x = x[:, 0].reshape(-1, 1)
 
         return self.lr_.predict_proba(x)[:, 1]


### PR DESCRIPTION
In this case, (for example a degenerated probability distribution of 0 for all datapoints) the "abm" variant crashes during predict, because the logistic regression is called with the wrong amount of parameters

https://github.com/betacal/python/blob/3a9dbb4bfa8b81ff1adbb979e1d6d4dbd8106ddc/betacal/beta_calibration.py#L115-L120

This happens because the logistic regressions coefficients get 0 for such a degenerated case, and the lines above are executed accidentally.
De-aliasing the accidental 0 case with a None variable solves that issue.